### PR TITLE
Fix: method has incompatible type for trait

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -53,7 +53,7 @@ impl bb8::ManageConnection for PostgresConnectionManager {
     fn is_valid
         (&self,
          conn: Self::Connection)
-         -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)>> {
+         -> Box<Future<Item = Self::Connection, Error = (Self::Error, Self::Connection)> + Send> {
         conn.batch_execute("")
     }
 


### PR DESCRIPTION
Compiling `bb8-postgres` fails with the following error on method `is_valid`:

note: expected type `fn(&PostgresConnectionManager, tokio_postgres::Connection) -> std::boxed::Box<(dyn futures::Future<Item=tokio_postgres::Connection, Error=(tokio_postgres::Error, tokio_postgres::Connection)> + std::marker::Send + 'static)>`
              found type `fn(&PostgresConnectionManager, tokio_postgres::Connection) -> std::boxed::Box<(dyn futures::Future<Item=tokio_postgres::Connection, Error=(tokio_postgres::Error, tokio_postgres::Connection)> + 'static)>`